### PR TITLE
PPSE-701: upgrading base image to debian:9 as java:8-jdk is no longer…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM    java:8-jdk
+FROM debian:9
 
 RUN apt-get update --fix-missing
 RUN apt-get install -y net-tools \
                    dnsutils \
                    supervisor \
+                   openjdk-8-jdk \
                    maven
 
 # Bundle app source


### PR DESCRIPTION
… supported